### PR TITLE
Add support for phpBB v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,19 @@ env:
   IMAGE_ICC: 1
   EPV: 1
   EXECUTABLE_FILES: 1
-  PHPBB_BRANCH: 3.3.x
+  PHPBB_BRANCH: master
 
 jobs:
   basic-tests:
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     name: php ${{ matrix.php-version }}, none none
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.php-version }}
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4']
+        php-version: ['8.1']
     steps:
       - name: Checkout phpBB
         uses: actions/checkout@v5
@@ -96,7 +96,7 @@ jobs:
   mysql-tests:
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     name: php ${{ matrix.php-version }}, ${{ matrix.db-type }} ${{ matrix.db-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       mysql:
         image: ${{ (matrix.db-type == 'mysql' || matrix.db-type == 'mariadb') && matrix.db-type || 'mariadb' }}:${{ (matrix.db-type == 'mysql' || matrix.db-type == 'mariadb' && matrix.db-version != 'none') && matrix.db-version || 'latest' }}
@@ -118,15 +118,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php-version: '7.4'
+          - php-version: '8.1'
             db-type: 'mysql'
-            db-version: '8.0'
-          - php-version: '7.4'
-            db-type: 'mariadb'
-            db-version: '10.5'
-          - php-version: '8.0'
-            db-type: 'mariadb'
-            db-version: '10.5'
+            db-version: '5.7'
           - php-version: '8.1'
             db-type: 'mariadb'
             db-version: '10.6'
@@ -200,7 +194,7 @@ jobs:
   postgresql-tests:
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     name: php ${{ matrix.php-version }}, ${{ matrix.db-type }} ${{ matrix.db-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: ${{ (matrix.db-type == 'postgres') && matrix.db-type || 'postgres' }}:${{ (matrix.db-type == 'postgres' && matrix.db-version != 'none') && matrix.db-version || 'alpine' }}
@@ -223,12 +217,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php-version: '7.4'
-            db-type: 'postgres'
-            db-version: '16-alpine'
-          - php-version: '8.4'
+          - php-version: '8.1'
             db-type: 'postgres'
             db-version: '17-alpine'
+          - php-version: '8.4'
+            db-type: 'postgres'
+            db-version: '18-alpine'
     steps:
       - name: Checkout phpBB
         uses: actions/checkout@v5

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
 	"type": "phpbb-extension",
 	"description": "Image Alternate Text extension for phpBB",
 	"homepage": "https://github.com/AlfredoRamos/phpbb-ext-image-alt",
-	"version": "1.1.0",
-	"time": "2020-01-06",
+	"version": "2.0.0-dev",
+	"time": "2025-09-30",
 	"keywords": [
 		"phpbb",
 		"extension",
@@ -21,7 +21,7 @@
 		}
 	],
 	"require": {
-		"php": "^7.4.0 || ^8.0.0",
+		"php": "^8.1.0",
 		"composer/installers": "^2.2.0"
 	},
 	"require-dev": {
@@ -31,7 +31,7 @@
 	"extra": {
 		"display-name": "Image Alternate Text",
 		"soft-require": {
-			"phpbb/phpbb": "~3.3.0"
+			"phpbb/phpbb": "~4.0.0"
 		},
 		"version-check": {
 			"host": "alfredoramos.mx",

--- a/ext.php
+++ b/ext.php
@@ -14,12 +14,10 @@ use phpbb\extension\base;
 class ext extends base
 {
 	/**
-	 * Check whether or not the extension can be enabled.
-	 *
-	 * @return bool
+	 * {@inheritdoc}
 	 */
 	public function is_enableable()
 	{
-		return phpbb_version_compare(PHPBB_VERSION, '3.3.0', '>=');
+		return phpbb_version_compare(PHPBB_VERSION, '4.0.0-a1-dev', '>='); // TODO: Use stable version
 	}
 }

--- a/tests/functional/imagealt_test.php
+++ b/tests/functional/imagealt_test.php
@@ -12,7 +12,7 @@ namespace alfredoramos\imagealt\tests\functional;
 /**
  * @group functional
  */
-class imageatl_test extends \phpbb_functional_test_case
+class imagealt_test extends \phpbb_functional_test_case
 {
 	static protected function setup_extensions()
 	{


### PR DESCRIPTION
- [ ] Fix `TODO` comments
  - [ ] Tests
  - [x] CI workflow
- [ ] Update required tests in repository settings
  - [ ] Remove tests for PHP < 8.1
  - [ ] Add missing tests for PHP >= 8.1
- [ ] Merge when phpBB v4.0.0 is released
- [ ] Update README
- [ ] Fix `phpBB3` routes in CI workflow